### PR TITLE
Make Git dependency explicit on Windows

### DIFF
--- a/0repo.xml
+++ b/0repo.xml
@@ -37,6 +37,10 @@
       <version not-before="2.2-post"/>
     </requires>
 
+    <requires interface="http://0install.de/feeds/msysgit.xml" os="Windows">
+      <environment name="PATH" insert="."/>
+    </requires>
+
     <implementation id="." version="0.3-post"/>
   </group>
 </interface>


### PR DESCRIPTION
By pulling in msysgit as a dependency on Windows we can guarantee that `git` is in the `PATH`.

Perhaps a platform independent feed at e.g. `http://repo.roscidus.com/devel/git` (with a `<feed>` reference to msysgit) would be a better solution in the long run.
