### PR TITLE
Fixed handling of non-ASCII characters in commit messages on Windows (again)

### DIFF
--- a/repo/scm.py
+++ b/repo/scm.py
@@ -38,7 +38,7 @@ def commit(cwd, paths, msg, key, extra_options = []):
 	if os.name == 'nt':
 		# Windows may choke on non-ASCII characters in command-line arguments
 		import urllib
-		msg = urllib.quote_plus(msg)
+		msg = urllib.quote(msg.encode('utf8'))
 
 	env['GIT_COMMITTER_NAME'] = name
 	env['GIT_COMMITTER_EMAIL'] = email


### PR DESCRIPTION
Unfortunately my original patch for this issue still caused an exception for some characters, such as Umlauts.
