### PR TITLE
Redesigned Catalog stylesheet

### DIFF
--- a/resources/catalog.css
+++ b/resources/catalog.css
@@ -1,62 +1,50 @@
-h1 { text-align: center; border-bottom: 2px solid #d0d0ff; padding-bottom: .5em; }
-div.main { padding: 1em; background: white; -moz-border-radius: 1em 1em 1em 1em; max-width: 60em;	margin-left: auto; margin-right: auto; margin-top: 1em; margin-bottom: 1em; }
-dt { font-weight: bold; text-transform:capitalize; }
-dd { padding-bottom: 1em; }
-dl.group { margin: 0.5em; padding: 0.5em; border: 1px dashed #888;}
-dl.impl { padding: 0.2em 1em 0.2em 1em; margin: 0.5em; border: 1px solid black; background: white;}
-pre { background: #ddd; color: black; padding: 0.2cm; }
-table { width: 100% }
-
-span.count {
-	color: #888;
-	padding-left: 1em;
+#main {
+    background: white;
+    max-width: 50em;
+    margin: 1em auto;
+}
+h1 {
+    text-align: center;
 }
 
-td.image {
-	text-align: center;
-	vertical-align: top;
+.search {
+    width: 100%;
 }
 
+.app {
+    display: flex;
+    min-height: 64px;
+    align-items: center;
+}
+.app:nth-child(even) {
+    background-color: #EEE;
+}
+
+.icon {
+    width: 42px;
+    flex-shrink: 0;
+    padding: 0.5rem 0 0.5rem 0.5rem;
+}
+
+.info {
+    flex-grow: 1;
+    padding: 0.5rem 0 0.5rem 0.5rem;
+}
+.name {
+    font-size: 1.1rem;
+    margin: 0;
+}
 .summary {
-	margin: 0;
-	padding: 0 0 1em 0;
-	font-style: italic;
-	color: #666;
+    vertical-align: top;
+    float: left;
+    margin: 0;
+}
+.details {
+    vertical-align: bottom;
+    float: right;
+    margin: 0;
 }
 
-tr.d0 td {
-	background: #eee;
-}
-
-td.keyinfo {
-	width: 10em;
-	vertical-align: top;
-}
-
-td.keyinfo a {
-	font-family: sans-serif;
-	font-weight: bold;
-	text-decoration: none;
-}
-
-td.keyinfo span.summary {
-	font-size: smaller;
-	font-style: italic;
-	color: #333;
-}
-
-td.teaser {
-	vertical-align: top;
-	color: #666;
-}
-
-td.teaser:hover {
-	color: #000;
-}
-
-td.teaser a {
-	display: block;
-	text-align: right;
-	float: right;
-	color: #66f;
+.actions {
+    padding: 1rem;
 }

--- a/resources/catalog.xsl
+++ b/resources/catalog.xsl
@@ -1,55 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet xmlns="http://www.w3.org/1999/xhtml"
-		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:interface="http://zero-install.sourceforge.net/2004/injector/interface"
-		xmlns:catalog="http://0install.de/schema/injector/catalog"
-		version="1.0">
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:interface="http://zero-install.sourceforge.net/2004/injector/interface"
+    xmlns:catalog="http://0install.de/schema/injector/catalog"
+    version="1.0">
+  <xsl:output method="xml" encoding="utf-8"
+        doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
+        doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"/>
+  <xsl:template match="/catalog:catalog">
+    <html>
+      <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta http-equiv="Content-Language" content="en" />
+        <title>Zero Install - Software catalog</title>
+        <link rel="stylesheet" href="resources/catalog.css" type="text/css" />
+        <script src="http://cdnjs.cloudflare.com/ajax/libs/list.js/1.1.1/list.min.js"></script>
+      </head>
 
-	<xsl:output method="xml" encoding="utf-8"
-		    doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
-		    doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"/>
-
-	<xsl:template match="/catalog:catalog">
-<html>
-
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="Content-Language" content="en" />
-<title>Software in this repository</title>
-<link rel="stylesheet" href="resources/catalog.css" type="text/css" />
-</head>
-
-<body>
-<div class='main'>
-<h1>Software in this repository</h1>
-
-<p>To start one of these programs, drag the program's title from your web-browser to <a href="http://0install.net/">0install</a>.</p>
-
-<table>
-<xsl:for-each select='interface:interface'>
-<tr class='d{position() mod 2}'>
-<xsl:variable name='icon' select='interface:icon/@href'/>
-<td class="image" width="48"><xsl:if test='$icon'><img src='{$icon}' alt="Application icon" width="48" height="48"/></xsl:if><xsl:if test='not($icon)'><img src='http://0install.net/tango/applications-system.png' alt="" width="48" height="48"/></xsl:if></td>
-<td class="keyinfo">
-<a href="{@uri}"><xsl:value-of select='interface:name'/></a><br/>
-<span class="summary"><xsl:if test='interface:summary[@xml:lang="en"]'><xsl:value-of select='interface:summary[@xml:lang="en"]'/></xsl:if><xsl:if test='not(interface:summary[@xml:lang="en"])'><xsl:value-of select='interface:summary'/></xsl:if></span>
-</td>
-<td class="teaser"><xsl:if test='interface:description[@xml:lang="en"]'><xsl:value-of select='interface:description[@xml:lang="en"]'/></xsl:if><xsl:if test='not(interface:description[@xml:lang="en"])'><xsl:value-of select='interface:description'/></xsl:if>
-<xsl:if test='string(interface:homepage)'><a href='{interface:homepage}'>Homepage</a></xsl:if>
-</td>
-</tr>
-</xsl:for-each>
-</table>
-
-<p>Number of feeds: <xsl:value-of select="count(//interface:interface)"/></p>
-
-<p>If you want to make additional programs available this way, see the
-<a href="http://0install.net/packagers.html">Packaging Guide</a>.</p>
-
-</div>
-</body>
-
-</html>
-	</xsl:template>
-
+      <body>
+        <div id="main">
+          <h1>Zero Install - Software catalog</h1>
+          <input class="search" placeholder="Search" />
+          <div class="list">
+            <xsl:for-each select="interface:interface">
+              <div class="app">
+                <xsl:variable name="icon" select="interface:icon[@type='image/png']/@href"/>
+                <xsl:if test="$icon">
+                  <img class="icon" src="{$icon}"/>
+                </xsl:if>
+                <xsl:if test="not($icon)">
+                  <img class="icon" src="http://0install.net/tango/applications-system.png"/>
+                </xsl:if>
+                <div class="info">
+                  <h2 class="name">
+                    <xsl:value-of select="interface:name"/>
+                  </h2>
+                  <p class="summary">
+                    <xsl:if test="interface:summary[@xml:lang='en']">
+                      <xsl:value-of select="interface:summary[@xml:lang='en']"/>
+                    </xsl:if>
+                    <xsl:if test="not(interface:summary[@xml:lang='en'])">
+                      <xsl:value-of select="interface:summary"/>
+                    </xsl:if>
+                  </p>
+                  <a class="details" href="{@uri}">Details...</a>
+                </div>
+                <div class="actions">
+                  <form action="http://0install.de/bootstrap/" method="get">
+                    <input type="hidden" name="name" value="{interface:name}"/>
+                    <input type="hidden" name="uri" value="{@uri}"/>
+                    <input type="submit" value="Run"/>
+                  </form>
+                </div>
+              </div>
+            </xsl:for-each>
+          </div>
+        </div>
+        <script>new List('main', {valueNames: ['name']});</script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
I have created a new Catalog stylesheet that approximates the look of the Zero Install Windows UI.
It embeds [List.js](http://www.listjs.com/) via CDN to provide incremental search/filtering.
It adds "Run" buttons that point to the 0bootstrap-php instance hosted on 0install.de.

You can see an instance of the stylesheet in use here: http://0install.de/catalog/