### PR TITLE
Catalog stylesheet: Use protocol-relative link for CDN-hosted JavaScript

### DIFF
--- a/resources/catalog.xsl
+++ b/resources/catalog.xsl
@@ -14,7 +14,7 @@
         <meta http-equiv="Content-Language" content="en" />
         <title>Zero Install - Software catalogue</title>
         <link rel="stylesheet" href="@REPOSITORY_BASE_URL@/resources/catalog.css" type="text/css" />
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/list.js/1.1.1/list.min.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.1.1/list.min.js"></script>
       </head>
 
       <body>


### PR DESCRIPTION
This avoids browser warnings about "mixed content" when accessing a catalog via HTTPS.