### PR TITLE
Use standalone GnuPG and not MSYS-version bundled with Git for Windows

### DIFF
--- a/0repo.xml
+++ b/0repo.xml
@@ -38,7 +38,11 @@
     </requires>
 
     <requires interface="http://repo.roscidus.com/git/core">
-      <environment insert="." name="PATH"/>
+      <executable-in-path name="git"/>
+    </requires>
+
+    <requires interface="http://repo.roscidus.com/security/gnupg">
+      <executable-in-path name="gpg"/>
     </requires>
 
     <implementation id="." version="0.4-post"/>


### PR DESCRIPTION
The two versions use different default home dirs (`%appdata%\GnuPG` vs `%userprofile%\.gnupg`) which could lead to confusion.

This depends on 0install/repo.roscidus.com#26