### PR TITLE
Make tracking of "testing" implemenations configurable

### DIFF
--- a/repo/cmd/update.py
+++ b/repo/cmd/update.py
@@ -56,6 +56,10 @@ def do_update(config, messages = None):
 		print(out)
 		print("Run 'git commit -a' from that directory to save your changes.")
 
+	if getattr(config, 'TRACK_TESTING_IMPLS', True):
+		graduation_check(feeds, feeds_dir)
+
+def graduation_check(feeds, feeds_dir):
 	# Warn about releases that are still 'testing' a while after release
 	now = time.time()
 	def age(impl):

--- a/repo/incoming.py
+++ b/repo/incoming.py
@@ -179,7 +179,7 @@ def process(config, xml_file, delete_on_success):
 	# Step 3 : merge XML into feeds directory
 
 	# Prompt about existing testing versions
-	if new_xml is None:
+	if new_xml is None and getattr(config, 'TRACK_TESTING_IMPLS', True):
 		new_versions = frozenset(impl.get_version() for impl in feed.implementations.values())
 		if len(new_versions) == 1:
 			ask_if_previous_still_testing(new_doc, list(new_versions)[0])

--- a/resources/0repo-config.py.template
+++ b/resources/0repo-config.py.template
@@ -161,6 +161,9 @@ def check_new_impl(impl):
 
 	return None
 
+# Prompt about old implementations that remain in the "testing" stability level for too long.
+# Set this to False if you intend to permanently mark releases as testing, e.g., release candidates.
+TRACK_TESTING_IMPLS = True
 
 #### Repository Layout (advanced) ####
 


### PR DESCRIPTION
This introduces a new option in `0repo-config.py`.

Motivation: I host a number of feeds with "release candidate" implementations which I would like to keep marked as "testing" permanently.