### PR TITLE
Sort feeds alphabetically before importing

### DIFF
--- a/repo/incoming.py
+++ b/repo/incoming.py
@@ -231,7 +231,7 @@ def process_incoming_dir(config):
 	messages = []
 
 	if new_xml:
-		for xml in new_xml:
+		for xml in sorted(new_xml):
 			print("Processing", xml)
 			msg = process(config, os.path.join('incoming', xml), delete_on_success = True)
 			if msg:


### PR DESCRIPTION
This makes the order of new implementations more predictable when importing multiple versions of a single app.

Useful in combination with [0watch](https://github.com/0install/0watch).