### PR TITLE
Remove elements which were moved out to a group

### DIFF
--- a/repo/merge.py
+++ b/repo/merge.py
@@ -251,7 +251,7 @@ def merge(master_doc, local_doc):
 
 		# Already copied to parent <group>
 		for x in list(childNodes(new_impl, XMLNS_IFACE)):
-			if x.localName in ('command', 'requires'):
+			if x.localName in ['command'] + list(requires_names):
 				new_impl.removeChild(x)
 
 		# Attributes might have been set on a parent group; move to the impl

--- a/tests/testmerge.py
+++ b/tests/testmerge.py
@@ -193,6 +193,23 @@ class TestMerge(unittest.TestCase):
   <implementation id="sha1=234" version="2"/>
 </group>""")
 
+	def testMergeEnvironment(self):
+		check_merge("""\
+<group>
+  <environment name='foo' append='bar'/>
+  <implementation id='sha1=123' version='1'/>
+</group>""", """\
+<group>
+  <implementation id='sha1=234' version='2'>
+    <environment name='foo' append='bar'/>
+  </implementation>
+</group>""", """\
+<group>
+  <environment name='foo' append='bar'/>
+  <implementation id="sha1=123" version="1"/>
+  <implementation id="sha1=234" version="2"/>
+</group>""")
+
 	def testMergeText(self):
 		check_merge("""\
 <group>


### PR DESCRIPTION
This is the same as #35, but squashed into one commit and then with a unit-test added.

Fixes #34.