### PR TITLE
 Add new "0repo modify" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,13 @@ let 0repo upload it automatically.
 Editing feeds
 -------------
 
-You can edit the unsigned feeds under repo/feeds whenever you want. Running
-0repo again will regenerate the signed feeds in repo/public (if the source feed
+You can edit the unsigned feeds under `repo/feeds` whenever you want. Running
+`0repo` again will regenerate the signed feeds in repo/public (if the source feed
 has changed). You should commit your changes with `git commit`.
+
+You can also run `0repo modify URI (ID|VERSION) --stability=STABILITY` to modify
+the stability rating of one or more implementations in a feed with a specific URI.
+This is useful, e.g., for promoting a `testing` release to `stable`.
 
 To remove a feed, `git rm repo/feeds/FEED.xml` and run `0repo` again.
 
@@ -230,12 +234,11 @@ Retracting a release
 --------------------
 
 If you make a release and then want to remove it, you have several options. You can
-edit the feed in the `feeds` directory and set the stability to `buggy`, e.g.
+set the stability to `buggy`, e.g.
 
-    <implementation id="..." version="..." stability="buggy">
+    0repo modify http://my/feed.yml 1.0 --stability=buggy
 
-Then run `0repo update` to push the new XML to the server. The release still exists,
-but 0install will avoid selecting it by default.
+The release still exists, but 0install will avoid selecting it by default.
 
 If you've just made a release and want to remove it completely, you can `git revert`
 the commit that added it. Use `git log` to see the last log entry for your feed, e.g.

--- a/repo/cmd/__init__.py
+++ b/repo/cmd/__init__.py
@@ -22,6 +22,11 @@ def main(argv):
 	parser_import.add_argument('path', metavar='PATH', nargs='+',
 			   help='the signed feeds to import')
 
+	parser_modify = subparsers.add_parser('modify', help='modify implementations in an existing feed')
+	parser_modify.add_argument('uri', metavar='URI', help='the URI of the feed to modify')
+	parser_modify.add_argument('id', metavar='ID', help='the ID or version number of the implementations to modify')
+	parser_modify.add_argument('--stability', metavar='STABILITY', help='the new stability rating to set for the implementations')
+
 	parser_create = subparsers.add_parser('create', help='create a new repository')
 	parser_create.add_argument('path', metavar='DIR',
 			   help='the directory to create to hold the new repository')

--- a/repo/cmd/modify.py
+++ b/repo/cmd/modify.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2018, Bastian Eicher
+# See the README file for details, or visit http://0install.net.
+
+from __future__ import print_function
+
+import os
+from os.path import join
+from xml.dom import minidom, Node
+
+from repo import cmd, registry, merge, incoming, formatting
+from repo.cmd import update
+
+def handle(args):
+	if not cmd.find_config(missing_ok = True):
+		from_registry = registry.lookup(args.uri)
+		assert from_registry['type'] == 'local', 'Unsupported registry type in %s' % from_registry
+		os.chdir(from_registry['path'])
+
+	config = cmd.load_config()
+
+	rel_uri = args.uri[len(config.REPOSITORY_BASE_URL):]
+	feed_path = join('feeds', config.get_feeds_rel_path(rel_uri))
+	with open(feed_path, 'rb') as stream:
+		doc = minidom.parse(stream)
+
+	messages = []
+	for impl in merge.find_impls(doc.documentElement):
+		impl_id = impl.getAttribute("id")
+		impl_version = impl.getAttribute("version")
+		impl_stability = impl.getAttribute("stability")
+		if impl_id == args.id or impl_version == args.id:
+			if args.stability and impl_stability != args.stability:
+				messages.append('Implementation {id} (version {version}) stability set to {stability}'.format(
+					id = impl_id, version = impl_version, stability = args.stability))
+				impl.setAttribute("stability", args.stability)
+
+	if len(messages) > 0:
+		commit_msg = 'Modified {uri}\n\n{messages}'.format(uri = args.uri, messages = '\n'.join(messages))
+		new_xml = formatting.format_doc(doc)
+		incoming.write_to_git(feed_path, new_xml, commit_msg, config)
+		update.do_update(config)


### PR DESCRIPTION
This makes it easy to bump the stability rating from `testing` to `stable`, e.g. from within an automated release pipeline.

Usage sample:

    0repo modify http://my/feed.yml 1.0 --stability=buggy