### PR TITLE
Ignore subkeys when creating a repository

### DIFF
--- a/repo/cmd/create.py
+++ b/repo/cmd/create.py
@@ -19,11 +19,16 @@ def handle(args):
 	except subprocess.CalledProcessError as ex:
 		raise SafeException("GPG key '{key}' not found ({ex})".format(key = args.key, ex = ex))
 
+	in_ssb = False
 	fingerprint = None
 	for line in keys.split('\n'):
 		bits = line.split(':')
-		if bits[0] == 'fpr':
-			if fingerprint is None:
+		if bits[0] == 'ssb': in_ssb = True
+		elif bits[0] == 'sec': in_ssb = False
+		elif bits[0] == 'fpr':
+			if in_ssb and fingerprint is not None:
+				pass	# Ignore sub-keys (unless we don't have a primary - can that happen?)
+			elif fingerprint is None:
 				fingerprint = bits[9]
 			else:
 				raise SafeException("Multiple GPG keys match '{key}':\n{output}".format(


### PR DESCRIPTION
Newer versions of Gnupg (tested with `gpg (GnuPG) 2.1.18`) return multiple fingerprints. This caused the unit-tests to fail, but is also a problem for users.

Fixes #33 (hopefully).

Unit-test error was:

    Multiple GPG keys match 'Test Key for 0repo'