### PR TITLE
Make GnuPG signing optional

### DIFF
--- a/repo/build.py
+++ b/repo/build.py
@@ -22,6 +22,9 @@ feed_header = """<?xml version="1.0" ?>
 """
 
 def sign_xml(config, source_xml):
+	if not config.GPG_SIGNING_KEY:
+		return source_xml
+
 	child = subprocess.Popen(['gpg', '--detach-sign', '--default-key', config.GPG_SIGNING_KEY, '--use-agent', '--output', '-', '-'],
 			stdin = subprocess.PIPE,
 			stdout = subprocess.PIPE,
@@ -158,9 +161,11 @@ def build_public_feeds(config):
 						changed = False
 				feeds.append(PublicFeed(abspath(source_path), public_rel_path, new_doc, changed))
 
-	key_path = export_key(join('public', 'keys'), config.GPG_SIGNING_KEY)
-
-	other_files = [relpath(key_path, 'public')]
+	if config.GPG_SIGNING_KEY:
+		key_path = export_key(join('public', 'keys'), config.GPG_SIGNING_KEY)
+		other_files = [relpath(key_path, 'public')]
+	else:
+		other_files = []
 
 	for public_feed in feeds:
 		target_path = join('public', public_feed.public_rel_path)
@@ -169,7 +174,7 @@ def build_public_feeds(config):
 		if not os.path.isdir(target_dir):
 			os.makedirs(target_dir)
 
-		if config.GPG_PUBLIC_KEY_DIRECTORY:
+		if config.GPG_SIGNING_KEY and config.GPG_PUBLIC_KEY_DIRECTORY:
 			key_symlink_rel_path = join(dirname(public_feed.public_rel_path), config.GPG_PUBLIC_KEY_DIRECTORY, basename(key_path))
 			other_files.append(key_symlink_rel_path)
 			key_symlink_path = join('public', key_symlink_rel_path)

--- a/repo/cmd/__init__.py
+++ b/repo/cmd/__init__.py
@@ -31,7 +31,7 @@ def main(argv):
 	parser_create.add_argument('path', metavar='DIR',
 			   help='the directory to create to hold the new repository')
 	parser_create.add_argument('key', metavar='GPGKEY',
-			   help='the GPG key used to sign the generated feeds and commits')
+			   help='the GPG key used to sign the generated feeds and commits; use "-" to disable GPG signing (e.g., for testing)')
 
 	subparsers.add_parser('register', help='add this repository location to ~/.config/...')
 

--- a/repo/cmd/create.py
+++ b/repo/cmd/create.py
@@ -13,29 +13,33 @@ from repo import scm
 topdir = dirname(dirname(dirname(abspath(__file__))))
 
 def handle(args):
-	# Get the fingerprint from the key ID (and check we have the secret key)
-	try:
-		keys = subprocess.check_output(['gpg', '-q', '--fixed-list-mode', '--fingerprint', '--with-colons', '--list-secret-keys', args.key])
-	except subprocess.CalledProcessError as ex:
-		raise SafeException("GPG key '{key}' not found ({ex})".format(key = args.key, ex = ex))
+	if args.key == '-':
+		key = None
+	else:
+		# Get the fingerprint from the key ID (and check we have the secret key)
+		try:
+			keys = subprocess.check_output(['gpg', '-q', '--fixed-list-mode', '--fingerprint', '--with-colons', '--list-secret-keys', args.key])
+		except subprocess.CalledProcessError as ex:
+			raise SafeException("GPG key '{key}' not found ({ex})".format(key = args.key, ex = ex))
 
-	in_ssb = False
-	fingerprint = None
-	for line in keys.split('\n'):
-		bits = line.split(':')
-		if bits[0] == 'ssb': in_ssb = True
-		elif bits[0] == 'sec': in_ssb = False
-		elif bits[0] == 'fpr':
-			if in_ssb and fingerprint is not None:
-				pass	# Ignore sub-keys (unless we don't have a primary - can that happen?)
-			elif fingerprint is None:
-				fingerprint = bits[9]
-			else:
-				raise SafeException("Multiple GPG keys match '{key}':\n{output}".format(
-					key = args.key, output = keys))
-	
-	if fingerprint is None:
-		raise SafeException("GPG key not found '{key}'".format(key = args.key))
+		in_ssb = False
+		fingerprint = None
+		for line in keys.split('\n'):
+			bits = line.split(':')
+			if bits[0] == 'ssb': in_ssb = True
+			elif bits[0] == 'sec': in_ssb = False
+			elif bits[0] == 'fpr':
+				if in_ssb and fingerprint is not None:
+					pass	# Ignore sub-keys (unless we don't have a primary - can that happen?)
+				elif fingerprint is None:
+					fingerprint = bits[9]
+				else:
+					raise SafeException("Multiple GPG keys match '{key}':\n{output}".format(
+						key = args.key, output = keys))
+
+		if fingerprint is None:
+			raise SafeException("GPG key not found '{key}'".format(key = args.key))
+		key = '0x' + fingerprint
 
 	# Create the directory structure
 	os.mkdir(args.path)
@@ -47,10 +51,10 @@ def handle(args):
 	# Write the configuration file, with the GPG key filled in
 	with open(join(topdir, 'resources', '0repo-config.py.template'), 'rt') as stream:
 		data = stream.read()
-	data = data.replace('{{GPGKEY}}', '0x' + fingerprint)
+	data = data.replace('"{{GPGKEY}}"', '"' + key + '"' if key else "None")
 	with open('0repo-config.py', 'wt') as stream:
 		stream.write(data)
 
 	# Initialise the Git repository
 	subprocess.check_call(['git', 'init', '-q', 'feeds'])
-	scm.commit('feeds', [], 'Created new repository', '0x' + fingerprint, extra_options = ['--allow-empty'])
+	scm.commit('feeds', [], 'Created new repository', key, extra_options = ['--allow-empty'])

--- a/repo/scm.py
+++ b/repo/scm.py
@@ -34,7 +34,12 @@ def uid_from_fingerprint(keyid):
 
 def commit(cwd, paths, msg, key, extra_options = []):
 	env = os.environ.copy()
-	name, email = uid_from_fingerprint(key)
+
+	if key:
+		name, email = uid_from_fingerprint(key)
+	else:
+		name = "0repo"
+		email = "<>"
 
 	env['GIT_COMMITTER_NAME'] = name
 	env['GIT_COMMITTER_EMAIL'] = email
@@ -46,7 +51,7 @@ def commit(cwd, paths, msg, key, extra_options = []):
 	try:
 		msg_file.write(msg.encode('utf-8'))
 		msg_file.close()
-		subprocess.check_call(['git', 'commit', '-q', '-F', msg_file.name, '-S' + key] + extra_options + ['--'] + paths,
+		subprocess.check_call(['git', 'commit', '-q', '-F', msg_file.name] + (['-S' + key] if key else []) + extra_options + ['--'] + paths,
 				      cwd = cwd,
 				      env = env)
 	finally:

--- a/resources/0repo-config.py.template
+++ b/resources/0repo-config.py.template
@@ -4,7 +4,7 @@ REPOSITORY_BASE_URL = "http://example.com/myrepo/"
 # The GPG secret key which 0repo should use to sign the generated feeds and any
 # Git commits it makes. The fingerprint preceeded by "0x" is the most precise
 # way to identity a key (see "HOW TO SPECIFY A USER ID" in the gpg(1) man-page
-# for other options).
+# for other options). Set this to None to disable GPG signing (e.g., for testing).
 GPG_SIGNING_KEY = "{{GPGKEY}}"
 
 # If set, XML feeds in the "incoming" directory and any Git pull requests must be signed by one of


### PR DESCRIPTION
This can be useful for automated merging and testing of incoming in CI environments.