### PR TITLE
Git commit signing improvements

### DIFF
--- a/0repo.xml
+++ b/0repo.xml
@@ -43,6 +43,7 @@
 
     <requires interface="http://repo.roscidus.com/security/gnupg">
       <executable-in-path name="gpg"/>
+      <executable-in-var name="GNUPG_PATH"/>
     </requires>
 
     <implementation id="." version="0.8-post"/>

--- a/repo/incoming.py
+++ b/repo/incoming.py
@@ -266,7 +266,7 @@ def write_to_git(feed_path, new_xml, commit_msg, config, new_file = False):
 			did_git_add = True
 
 		# (this must be last in the try block)
-		scm.commit('feeds', [git_path], commit_msg, key = config.GPG_SIGNING_KEY)
+		scm.commit('feeds', [git_path], commit_msg, key = config.GPG_SIGNING_KEY if getattr(config, 'SIGN_COMMITS', True) else None)
 	except Exception as ex:
 		# Roll-back (we didn't commit to Git yet)
 		print(ex)

--- a/resources/0repo-config.py.template
+++ b/resources/0repo-config.py.template
@@ -1,11 +1,16 @@
 # The URL of the directory which will host the repository (feeds, keys, stylesheets and catalogue).
 REPOSITORY_BASE_URL = "http://example.com/myrepo/"
 
-# The GPG secret key which 0repo should use to sign the generated feeds and any
-# Git commits it makes. The fingerprint preceeded by "0x" is the most precise
-# way to identity a key (see "HOW TO SPECIFY A USER ID" in the gpg(1) man-page
-# for other options). Set this to None to disable GPG signing (e.g., for testing).
+# The GPG secret key which 0repo should use to sign the generated feeds. The
+# fingerprint preceeded by "0x" is the most precise way to identity a key (see
+# "HOW TO SPECIFY A USER ID" in the gpg(1) man-page for other options). Set
+# this to None to disable GPG signing (e.g., for testing).
 GPG_SIGNING_KEY = "{{GPGKEY}}"
+
+# Controls whether 0repo should sign Git commits it makes.
+# Will use the same GPG secret key specified above.
+# Has no effect when GPG_SIGNING_KEY is set to None.
+SIGN_COMMITS = True
 
 # If set, XML feeds in the "incoming" directory and any Git pull requests must be signed by one of
 # these keys, otherwise they will be rejected. For local use, this can be set to None so that the


### PR DESCRIPTION
- Make signing of Git commits optional.
- Force Git for Windows to use same version of GnuPG as 0repo. This prevents problems with keys being available in one but not in the other. This is a replacement for the workaround removed in ec92fd0625c342201d45e47c82f0759ef6e87553.