### PR TITLE
Use forward slash as path separator in XML files on all platforms

### DIFF
--- a/repo/build.py
+++ b/repo/build.py
@@ -188,7 +188,7 @@ def build_public_feeds(config):
 
 		if not public_feed.changed: continue
 
-		path_to_resources = relpath(join('public', 'resources'), dirname(target_path))
+		path_to_resources = relpath(join('public', 'resources'), dirname(target_path)).replace(os.sep, '/')
 		new_xml = (feed_header % path_to_resources).encode('utf-8') + public_feed.doc.documentElement.toxml('utf-8') + '\n'
 
 		signed_xml = sign_xml(config, new_xml)


### PR DESCRIPTION
This prevents 0repo from generating something like this on Windows:

```xml
<?xml-stylesheet type='text/xsl' href='..\..\resources/feed.xsl'?>
```