### PR TITLE
Make 0repo easier to use in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,11 @@ Running in CI environments
 
 To completely skip GnuPG signatures (e.g., when running a CI build to verify a pull request) set the environment variable `NO_SIGN` to any non-empty value.
 
+To track the 0repo configuration in Git together with the feeds run:
+
+    mv 0repo-config.py feeds/0repo-config.py
+    ln -s feeds/0repo-config.py 0repo-config.py
+
 
 Repository files
 ----------------

--- a/README.md
+++ b/README.md
@@ -304,6 +304,12 @@ dependency to an already-released version), the contributor sends a Git pull
 request. The repository owner merges the pull request and runs 0repo.
 
 
+Running in CI environments
+--------------------------
+
+To completely skip GnuPG signatures (e.g., when running a CI build to verify a pull request) set the environment variable `NO_SIGN` to any non-empty value.
+
+
 Repository files
 ----------------
 

--- a/repo/catalog.py
+++ b/repo/catalog.py
@@ -21,7 +21,7 @@ catalog_header = b'''<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='%s/catalog.xsl'?>
 '''
 
-catalog_names = frozenset(["name", "summary", "description", "homepage", "icon", "category", "entry-point"])
+catalog_names = frozenset(["name", "summary", "description", "homepage", "icon", "category", "needs-terminal", "entry-point"])
 
 def write_catalogs(config, feeds):
 	feeds_by_directory = collections.defaultdict(lambda: [])

--- a/repo/incoming.py
+++ b/repo/incoming.py
@@ -199,6 +199,7 @@ def process(config, xml_file, delete_on_success):
 
 def process_incoming_dir(config):
 	"""Current directory contains 'incoming'."""
+	os.makedirs('incoming', exist_ok=True)
 	incoming_files = os.listdir('incoming')
 	new_xml = []
 	for i in incoming_files:

--- a/resources/0repo-config.py.template
+++ b/resources/0repo-config.py.template
@@ -1,3 +1,10 @@
+# Some Python imports (needed for the code below) - you can leave these alone
+import os
+from repo import paths
+import subprocess
+from os.path import join
+
+
 # The URL of the directory which will host the repository (feeds, keys, stylesheets and catalogue).
 REPOSITORY_BASE_URL = "http://example.com/myrepo/"
 
@@ -5,7 +12,7 @@ REPOSITORY_BASE_URL = "http://example.com/myrepo/"
 # fingerprint preceeded by "0x" is the most precise way to identity a key (see
 # "HOW TO SPECIFY A USER ID" in the gpg(1) man-page for other options). Set
 # this to None to disable GPG signing (e.g., for testing).
-GPG_SIGNING_KEY = "{{GPGKEY}}"
+GPG_SIGNING_KEY = None if os.getenv('NO_SIGN') else "{{GPGKEY}}"
 
 # Controls whether 0repo should sign Git commits it makes.
 # Will use the same GPG secret key specified above.
@@ -17,13 +24,6 @@ SIGN_COMMITS = True
 # files don't need to be signed.
 CONTRIBUTOR_GPG_KEYS = None
 #CONTRIBUTOR_GPG_KEYS = { "DA9825AECAD089757CDABD8E07133F96CA74D8BA" }
-
-
-# Some Python imports (needed for the code below) - you can leave these alone
-import os
-from repo import paths
-import subprocess
-from os.path import join
 
 
 #### Feed hosting ####


### PR DESCRIPTION
- Automatically create `incoming` directory if missing
- Introduce `NO_SIGN` env var for skipping GnuPG signatures
- Add hint to readme about tracking `0repo-config.py` in Git
- Simplify Git hosting sample in `0repo-config.py` template (based on setup used by apps.0install.net)